### PR TITLE
fix: ask photo permissions only when filepicker is open

### DIFF
--- a/packages/stream_chat_flutter/lib/src/message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input.dart
@@ -1079,7 +1079,7 @@ class MessageInputState extends State<MessageInput> {
                               return const SizedBox.shrink();
                             },
                           )
-                        : Container(),
+                        : const SizedBox(),
                   ],
                 ),
                 DecoratedBox(

--- a/packages/stream_chat_flutter/lib/src/message_input.dart
+++ b/packages/stream_chat_flutter/lib/src/message_input.dart
@@ -1059,25 +1059,27 @@ class MessageInputState extends State<MessageInput> {
                             },
                     ),
                     const Spacer(),
-                    FutureBuilder(
-                      future: PhotoManager.requestPermissionExtend(),
-                      builder: (context, snapshot) {
-                        if (snapshot.hasData &&
-                            snapshot.data == PermissionState.limited) {
-                          return TextButton(
-                            child: Text(context.translations.viewLibrary),
-                            onPressed: () async {
-                              await PhotoManager.presentLimited();
-                              _mediaListViewController.updateMedia(
-                                newValue: true,
-                              );
-                            },
-                          );
-                        }
+                    _openFilePickerSection
+                        ? FutureBuilder(
+                            future: PhotoManager.requestPermissionExtend(),
+                            builder: (context, snapshot) {
+                              if (snapshot.hasData &&
+                                  snapshot.data == PermissionState.limited) {
+                                return TextButton(
+                                  child: Text(context.translations.viewLibrary),
+                                  onPressed: () async {
+                                    await PhotoManager.presentLimited();
+                                    _mediaListViewController.updateMedia(
+                                      newValue: true,
+                                    );
+                                  },
+                                );
+                              }
 
-                        return const SizedBox.shrink();
-                      },
-                    ),
+                              return const SizedBox.shrink();
+                            },
+                          )
+                        : Container(),
                   ],
                 ),
                 DecoratedBox(


### PR DESCRIPTION
fix: ask photo permissions only when filepicker is open

ref: https://www.notion.so/indaband/Permission-request-when-opening-chat-70ca9ca9d02d42ac9b61480170ba7c31